### PR TITLE
Bump Argo CD application-controller memory: 1Gi → 2Gi

### DIFF
--- a/cluster/argo-cd/values.yaml
+++ b/cluster/argo-cd/values.yaml
@@ -22,10 +22,10 @@ argo-cd:
       minAvailable: 1
     resources:
       limits:
-        memory: 1Gi
+        memory: 2Gi
       requests:
         cpu: 250m
-        memory: 1Gi
+        memory: 512Mi
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
## Summary
- Controller OOMKilled ~5300 times at the 1Gi limit (cycle ~90 min)
- Working set right after a restart is ~489 MiB; grows with informer cache as the ~38 Argo Applications reconcile
- Bumps limit 1Gi → 2Gi for headroom; drops request to 512Mi (Burstable QoS) so we don't reserve capacity we rarely use

## Test plan
- [ ] Merge → Argo self-syncs the new chart values via the `argocd-install` Application
- [ ] `kubectl -n argo-cd get pod argo-install-argocd-application-controller-0 -o jsonpath='{.spec.containers[0].resources}'` shows the new request/limit
- [ ] `kubectl -n argo-cd top pod` watched for one full reconcile cycle; working set stabilizes well below 2Gi
- [ ] Restart count stops climbing

Refs #2502