### PR TITLE
shrink MetalLB pool to .6-.8 (resolve VyOS DHCP overlap)

### DIFF
--- a/cluster/metallb/pool.yaml
+++ b/cluster/metallb/pool.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   autoAssign: true
   addresses:
-    - 192.168.0.6-192.168.0.10
+    - 192.168.0.6-192.168.0.8
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
## Summary
- Pool is `192.168.0.6-.10`; VyOS DHCP range is `.9-.239` — they overlap at `.9` and `.10`
- `.9` is currently leased to a DHCP client (google-home-mini); MetalLB hasn't tried to claim it yet because nothing has needed a second LB IP
- Shrink the pool to `.6-.8` (3 IPs) so the overlap is gone

After shrink:
- `.6` = ingress-nginx (live, untouched)
- `.7`, `.8` = free for the Traefik migration when that lands

If/when we need more LB IPs, we widen — but VyOS DHCP would also need to shrink in that case, separate coordinated change.

## Test plan
- [ ] Merge → Argo applies the new IPAddressPool
- [ ] `kubectl -n metallb-system get ipaddresspool pool -o yaml` shows the new range
- [ ] Existing ingress at `.6` still serves
- [ ] DHCP keeps handing out `.9-.30` as before

Refs #2509