### PR TITLE
add cluster-snapshot + ceph-doctor skills

### DIFF
--- a/.claude/skills/ceph-doctor/SKILL.md
+++ b/.claude/skills/ceph-doctor/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: ceph-doctor
+description: Read-only Ceph inspection workflow when the cluster is showing degraded/error/warn state. Identifies inconsistent PGs, bad shards, OSD trouble, capacity issues — and proposes safe repair commands. Use when ceph -s is not HEALTH_OK, when the user mentions ceph/rook/storage problems, or before doing anything that depends on storage being healthy. NEVER runs `pg repair`, `osd out`, `osd destroy`, or any write command without explicit user approval.
+---
+
+# ceph-doctor
+
+Diagnose Ceph problems on galaxy without changing state. The default outcome is a written assessment + a proposed repair plan, **not** a repair.
+
+## Ground rules (CLAUDE.md S7)
+
+- All commands here are read-only. No exceptions.
+- `ceph pg repair`, `ceph osd out/down/destroy/reweight`, scrub-schedule changes, and pool config changes require **explicit user approval per command** before running. Show the command, explain the effect, ask, wait.
+- Inconsistent PGs do not auto-fix. Slow is correct.
+
+## Refresh kubeconfig if needed
+
+```bash
+nix-shell shell.nix --run 'TALOSCONFIG=$PWD/nodes/talosconfig \
+  talosctl -n 192.168.0.5 -e 192.168.0.5 kubeconfig --force /tmp/galaxy-kubeconfig'
+export KUBECONFIG=/tmp/galaxy-kubeconfig
+```
+
+## Find the toolbox pod
+
+Every ceph command goes through this pod:
+
+```bash
+TOOLS=$(kubectl -n rook get pod -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
+ceph() { kubectl -n rook exec "$TOOLS" -- ceph "$@"; }
+rados() { kubectl -n rook exec "$TOOLS" -- rados "$@"; }
+rbd() { kubectl -n rook exec "$TOOLS" -- rbd "$@"; }
+```
+
+## Inspect (in this order)
+
+1. **Top-level state**
+
+   ```bash
+   ceph -s
+   ceph health detail
+   ```
+
+2. **If `PG_DAMAGED` / `OSD_SCRUB_ERRORS` / inconsistent PGs**
+
+   For each inconsistent PG:
+   ```bash
+   ceph pg <pgid> query | jq '{state, last_deep_scrub_stamp, scrubber, last_scrub_stamp, num_scrub_errors: .info.stats.stat_sum.num_scrub_errors}'
+   rados list-inconsistent-obj <pgid> --format=json | jq '.inconsistents[] | {object: .object.name, errors, bad_shards: [.shards[] | select(.errors|length>0) | {osd, errors}]}'
+   ```
+
+   For each bad object: identify which shard's digest disagrees with the others. The shard with `data_digest_mismatch_info` is the bad one.
+
+3. **OSD layout**
+
+   ```bash
+   ceph osd tree
+   ceph osd df tree
+   ```
+
+   Note: which host hosts which OSDs. Bit-rot pattern (bad shards on different hosts) → individual disk media issue. Concentrated pattern (multiple bad OSDs on the same host) → controller / cable / PSU on that node.
+
+4. **Per-OSD trouble signs**
+
+   ```bash
+   ceph osd perf
+   ceph health detail | grep -i 'spurious\|slow\|crashed'
+   ```
+
+   `BLUESTORE_SPURIOUS_READ_ERRORS` is a transient warn — note but don't react.
+
+5. **Pool / RBD identification**
+
+   When an inconsistency hits an RBD object (`rbd_data.<image_id>.<offset>`), find the owning image and PVC:
+
+   ```bash
+   for img in $(rbd ls -p block-pool); do
+     rbd info -p block-pool "$img" 2>/dev/null | grep -q '<image_id>' && echo "MATCH: $img" && break
+   done
+
+   kubectl get pv -o json | jq -r '.items[] | select(.spec.csi.volumeAttributes.imageName == "<csi-vol-name>") | {pv: .metadata.name, claim: (.spec.claimRef.namespace + "/" + .spec.claimRef.name), capacity: .spec.capacity.storage}'
+   ```
+
+## Decide repair-safety
+
+For each inconsistent PG:
+
+- **2-of-3 majority of clean shards + primary is clean** → `ceph pg repair <pgid>` is safe. Repair will overwrite the single bad shard from the primary.
+- **2-of-3 majority of clean shards + primary is the bad shard** → still recoverable, but `pg repair` could propagate the bad data. Need to flag and discuss before any repair. Modern Ceph picks the shard whose digest matches `selected_object_info.data_digest`, so it's usually still safe — but explicitly verify by reading `.shards[*].data_digest` against `.selected_object_info.data_digest`.
+- **No clean majority (≤1 clean shard)** → don't `pg repair`. Stop and discuss with user. Possible recovery via object-store-tool, possible data loss.
+
+## Propose, don't execute
+
+In your response to the user:
+
+1. Summarize what you found in 5-7 lines (state, count of damaged PGs, root pattern, affected workload).
+2. Propose specific commands, one per line, with the consequence of each.
+3. Ask which to run.
+
+Never proactively run a `repair`/`out`/`destroy` even if confident.
+
+## When to escalate
+
+- Multiple OSDs on the same host with `BLUESTORE_SPURIOUS_READ_ERRORS` and growing → likely failing controller/cable/PSU. Recommend SMART check + dmesg inspection on that node, not Ceph commands.
+- `ceph -s` shows `pgs: ... incomplete` or `peering` → quorum / peering issue, not a data integrity issue. Different playbook.
+- Ceph capacity > 80% RAW USED → space crunch is its own emergency; recommend reaping unused PVs, growing storage, or purging snapshots before any other work.
+
+## Useful reads (for the model)
+
+- `ceph -s` "data" line: PG state distribution. `active+clean+inconsistent` means data is reachable but failing scrub.
+- A PG repair triggers an immediate deep scrub with the repair flag. On HDDs at homelab scale, expect 30-90 minutes per PG including the post-repair verify scrub.
+- `osd_scrub_sleep`, `osd_max_scrubs`, `osd_scrub_load_threshold` control how aggressive scrubs are. Don't tune mid-repair.

--- a/.claude/skills/cluster-snapshot/SKILL.md
+++ b/.claude/skills/cluster-snapshot/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cluster-snapshot
+description: Produce a structured health snapshot of the galaxy cluster — nodes, ceph, argo apps, not-ready pods, recent events. Use this before any cluster change or when the user asks "how is the cluster" / "what's broken" / "give me a health check".
+---
+
+# cluster-snapshot
+
+Run a curated set of read-only checks against galaxy and return a structured summary. Does not touch state.
+
+## Refresh kubeconfig if needed
+
+```bash
+nix-shell shell.nix --run 'TALOSCONFIG=$PWD/nodes/talosconfig \
+  talosctl -n 192.168.0.5 -e 192.168.0.5 kubeconfig --force /tmp/galaxy-kubeconfig'
+export KUBECONFIG=/tmp/galaxy-kubeconfig
+```
+
+Skip the refresh if `kubectl get nodes` already works.
+
+## Gather
+
+Run these in parallel where possible (Bash tool, multiple in one block):
+
+```bash
+# nodes + versions
+kubectl get nodes -o wide
+
+# argo applications: which are OutOfSync or unhealthy
+kubectl -n argo-cd get applications.argoproj.io -o wide
+
+# pods that should not be in a non-Running state
+kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
+
+# ceph state via rook toolbox
+TOOLS=$(kubectl -n rook get pod -l app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
+kubectl -n rook exec "$TOOLS" -- ceph -s
+kubectl -n rook exec "$TOOLS" -- ceph health detail
+
+# recent cluster events (last 10 min)
+kubectl get events -A --sort-by=.lastTimestamp | tail -30
+
+# resource pressure (if metrics-server up)
+kubectl top nodes
+kubectl top pods -A --sort-by=memory | head -15
+```
+
+## Report shape
+
+Reply to the user with these sections, in this order, terse:
+
+1. **Versions**: Talos / k8s / number of nodes / control-plane all schedulable?
+2. **Ceph**: `HEALTH_OK` / `HEALTH_WARN` / `HEALTH_ERR` + the one-line reason. If not OK, name the affected PGs / OSDs.
+3. **Argo**: count Synced+Healthy, list the OutOfSync, list the unhealthy.
+4. **Workload pods**: count not-Running. List up to 5 with namespace, name, reason. Note any pod with > 100 restarts.
+5. **Recent events**: anything Warning level in the last 10 min that isn't routine (FailedScheduling we already know about, image pulls).
+6. **Top resource users**: only if something is notably high (> 70% of limit).
+7. **Sharp edges**: still-known issues from CLAUDE.md "Known sharp edges" section that are unresolved.
+
+If everything is clean, say so in one sentence. Don't pad.
+
+## Don't
+
+- Don't run any write command. No `kubectl apply`, `delete`, `scale`, `rollout restart`. This skill is read-only.
+- Don't propose fixes inline — that's a separate conversation. Just report.
+- Don't dump raw command output into the response. Summarize.


### PR DESCRIPTION
## Summary
First two project-local Claude skills under `.claude/skills/`. Both are read-only by design and codify patterns we used during the audit + ceph triage today.

- **`cluster-snapshot`**: structured health summary (nodes, ceph, argo apps, not-ready pods, events, top users) with a tight reporting shape so future sessions get a fast picture of galaxy.
- **`ceph-doctor`**: read-only ceph inspection workflow with explicit repair-safety rules (2-of-3 majority + primary-clean check before proposing `pg repair`). Codifies CLAUDE.md S7 ("look-don't-poke").

Future skills to add:
- `safe-rollout` — wait-with-Monitor pattern for k8s rollouts and node drains
- `vyos-deploy` — wraps `commit-confirm 10` + Ansible deploy
- `talos-upgrade` — staggered upgrade runbook with health gates
- `traefik-migrate` — once we start the ingress migration

## Test plan
- [ ] Skills load: in a fresh Claude session in this repo, both skill names should appear in available-skills
- [ ] Triggering by description works: ask Claude something like "give me a cluster health snapshot" and verify it picks up `cluster-snapshot`
- [ ] Read-only: confirm by asking the skill to do something destructive — should refuse

Refs #2510