### PR TITLE
add safe-rollout + vyos-deploy skills, codify etcd snapshot path

### DIFF
--- a/.claude/skills/safe-rollout/SKILL.md
+++ b/.claude/skills/safe-rollout/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: safe-rollout
+description: Drive a Kubernetes Deployment/StatefulSet/DaemonSet rollout (or an Argo Application sync) and watch it to a definitive outcome — Ready, Failed, or Timeout — using the Monitor tool. Use whenever the user asks to deploy, restart, scale, or sync something that takes more than a few seconds, or whenever you've just merged a PR that changes a workload spec. NEVER busy-loops `kubectl get` in Bash. NEVER force-deletes pods to "speed it up". NEVER declares success without confirming all replicas Ready.
+---
+
+# safe-rollout
+
+Watch a workload rollout (or Argo sync) to completion without polling-loop antipatterns. The point is to not declare victory before the cluster has actually settled.
+
+## Hard rules (CLAUDE.md S3)
+
+- **Use `Monitor`** for any rollout watch > 60s. Never `until kubectl get …; do sleep 5; done` in foreground.
+- **Surface failure modes**, not just success. The watch must emit a line on Failed/Timeout, not just on Ready.
+- **Patience**: image pulls on cold start, RBD volume attach on a node that wasn't running it, and PDB-blocked drains are all *normal slow*. Don't kill pods to escape waiting.
+- **No `--force --grace-period=0`** unless explicitly authorized.
+- **Don't restart pods that are already Running** to "see if it helps" — that's fishing, not diagnosis.
+
+## Refresh kubeconfig if needed
+
+```bash
+nix-shell shell.nix --run 'TALOSCONFIG=$PWD/nodes/talosconfig \
+  talosctl -n 192.168.0.5 -e 192.168.0.5 kubeconfig --force /tmp/galaxy-kubeconfig'
+export KUBECONFIG=/tmp/galaxy-kubeconfig
+```
+
+## Pattern A — Deployment / StatefulSet / DaemonSet rollout
+
+```bash
+NS=argo-cd
+KIND=deploy
+NAME=argo-install-argocd-server
+
+# Capture pre-rollout state
+kubectl -n $NS get $KIND $NAME -o jsonpath='{.spec.replicas} desired, {.status.readyReplicas} ready' && echo
+
+# Trigger (whatever the change is — restart, scale, image bump applied)
+kubectl -n $NS rollout restart $KIND/$NAME
+
+# Watch with Monitor — emits one line per event, fails out on rollout failure
+# Use the Monitor tool with this command:
+#   kubectl -n NS rollout status KIND/NAME --watch --timeout=15m
+# Monitor will emit "deployment NAME rolled out" and exit when done,
+# or "error: timed out waiting for the condition" on timeout.
+```
+
+For DaemonSets (per-node rollouts), expect 1 update per node × ~30s each. For 3-node DS, ~90s minimum.
+
+## Pattern B — Argo Application sync
+
+```bash
+APP=argo-cd
+
+# Inspect first
+kubectl -n argo-cd get application $APP -o jsonpath='{.status.sync.status},{.status.health.status},{.status.operationState.phase}'
+
+# Trigger sync (this is rare — Argo self-heal usually handles it)
+nix-shell shell.nix --run 'argocd --grpc-web --core app sync '"$APP"
+
+# Watch via Monitor — emit on every status change
+# Monitor command (manual loop, since argocd CLI doesn't have --watch):
+#   prev=""
+#   while true; do
+#     cur=$(kubectl -n argo-cd get application '$APP' \
+#       -o jsonpath='{.status.sync.status}|{.status.health.status}|{.status.operationState.phase}')
+#     [ "$cur" != "$prev" ] && echo "[$(date +%T)] $cur"
+#     prev="$cur"
+#     case "$cur" in
+#       "Synced|Healthy|Succeeded"*) echo "DONE"; exit 0 ;;
+#       *"Failed"*|*"Degraded"*) echo "FAILED"; exit 1 ;;
+#     esac
+#     sleep 10
+#   done
+```
+
+## Pattern C — Node drain (e.g., before reboot)
+
+```bash
+NODE=middle
+
+# Cordon first so nothing new schedules
+kubectl cordon $NODE
+
+# Drain — this can take 5-30 min if there are stateful workloads
+# Use Monitor: emits a line per pod evicted; exits when complete or timeout
+#   kubectl drain $NODE --ignore-daemonsets --delete-emptydir-data --timeout=30m
+```
+
+If the drain stalls on a specific pod, **inspect** before forcing:
+```bash
+kubectl get pod -A --field-selector spec.nodeName=$NODE,status.phase=Running
+# For each blocking pod: is it owned by a workload that allows eviction (PDB)?
+# Most homelab workloads here have PDBs configured (argo, repo-server, redis).
+# If a PDB is blocking, that's by design — wait for the workload to schedule
+# its replacement on a different node first.
+```
+
+## Verification gates (apply to all patterns)
+
+After the Monitor exits successfully:
+
+1. **Replica match**: `kubectl -n $NS get $KIND $NAME` shows `desired = ready = up-to-date`
+2. **No pods crashing**: `kubectl -n $NS get pods` — all `Running`/`Completed`, no `CrashLoopBackOff`
+3. **No recent failures**: `kubectl -n $NS get events --sort-by=.lastTimestamp | tail -10` — no Warning events on this workload
+4. **Probes green**: for HTTP services, optionally `kubectl exec` curl the readiness path
+
+If gate 1 says ready but gate 2 has a flapping pod, **the rollout is not actually safe** even though `rollout status` exited 0. Surface and pause.
+
+## When to abort and surface
+
+- Monitor's command times out (default 15min for `rollout status`)
+- More than 3 restarts on any new pod within 5 min
+- Argo Application enters `Degraded` / `OutOfSync` after the sync attempt
+- Cluster events show `FailedScheduling`, `FailedAttachVolume`, `FailedMount` for the workload
+- Ceph goes from HEALTH_OK to HEALTH_WARN/ERR during the rollout (volume operations are stressing storage)
+
+Default response: stop, gather state, write up what you see, ask the user. Do not delete the failing pods to "let them retry".
+
+## What this skill does NOT do
+
+- Auto-rollback. If a rollout fails, surface and ask. The user owns rollback decisions.
+- `kubectl delete pod --force` to "unstick" things.
+- Edit Deployment specs to add/remove probes, resources, or labels mid-rollout.
+- Anti-affinity gymnastics. Workload placement is configured in the manifests; if pods aren't scheduling, fix the manifest, don't override at runtime.

--- a/.claude/skills/talos-upgrade/SKILL.md
+++ b/.claude/skills/talos-upgrade/SKILL.md
@@ -40,9 +40,14 @@ kubectl -n rook exec "$TOOLS" -- ceph health detail
 # 5. etcd member health (all 3 should report Running/Healthy)
 TALOSCONFIG=nodes/talosconfig talosctl -n 192.168.0.240,192.168.0.241,192.168.0.242 service etcd
 
-# 6. take an etcd snapshot before any k8s upgrade
-TALOSCONFIG=nodes/talosconfig talosctl -n 192.168.0.5 etcd snapshot /tmp/etcd-pre-upgrade-$(date +%Y%m%d-%H%M).db
+# 6. take an etcd snapshot before any k8s upgrade (dedicated path)
+mkdir -p ~/etcd-snapshots
+TALOSCONFIG=nodes/talosconfig talosctl -n 192.168.0.5 etcd snapshot \
+  ~/etcd-snapshots/galaxy-$(date +%Y%m%d-%H%M).db
+ls -la ~/etcd-snapshots/ | tail -5  # confirm it landed
 ```
+
+Snapshots accumulate; manually trim when there are >10 and you have a known-good cluster.
 
 If anything above is not green, **stop**. Surface to user.
 

--- a/.claude/skills/vyos-deploy/SKILL.md
+++ b/.claude/skills/vyos-deploy/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: vyos-deploy
+description: Apply a configuration change to the VyOS router via the Ansible playbooks under router/ansible/. Use when the user wants to change firewall rules, NAT, DHCP, interfaces, or any router config. Wraps the deploy in commit-confirm 10 so a misconfig auto-rolls-back if the operator can't reach the router. NEVER skips commit-confirm. NEVER touches router config outside the Ansible playbooks. NEVER pushes a change that would lock out SSH from the LAN.
+---
+
+# vyos-deploy
+
+Apply a router config change via the Ansible playbooks in `router/ansible/`, with `commit-confirm 10` as the safety net.
+
+The router is the single point of failure for the entire homelab — if a config commit locks SSH out, nothing else is reachable until physical console intervention. `commit-confirm` auto-rolls-back after 10 minutes if no `confirm` is issued, which buys us a "I can still reach it" reality check before the change becomes permanent.
+
+## Hard rules (CLAUDE.md S8)
+
+- **Always use `commit-confirm 10`** for changes that touch firewall, NAT, interfaces, DHCP, or anything that affects SSH reachability.
+- **Always preview first** with `ansible-playbook --check --diff` before applying.
+- **Never commit a config that drops SSH on the management network** without an explicit "I am at the console" sign-off from the user.
+- **Never edit live router config** outside Ansible. The playbook is the source of truth; manual edits drift.
+- **Backup before deploy.** The Ansible playbook does this automatically into `router/ansible/backups/` — verify the latest backup exists after the run.
+
+## Connectivity check
+
+```bash
+# SSH key must be in agent
+ssh-add -l | grep -q ed25519 || ssh-add ~/.ssh/id_ed25519
+
+# Reach test
+ssh -o BatchMode=yes chris@192.168.0.1 \
+  '/opt/vyatta/bin/vyatta-op-cmd-wrapper show version | head -3'
+```
+
+## Preview the change
+
+```bash
+cd router/ansible
+ansible-galaxy collection install -r requirements.yml  # if first run
+
+# Always check first
+ansible-playbook site.yml --check --diff
+```
+
+Read the diff. If the diff is empty, there's nothing to deploy.
+
+If the diff includes lines under `interfaces`, `firewall`, `nat`, `dhcp-server`, or `service ssh`, this is a high-risk change → use commit-confirm. If it's purely DNS, NTP, hostname, or container config, lower risk.
+
+## Apply with commit-confirm (high-risk changes)
+
+```bash
+# Open a commit-confirm window MANUALLY on the router first.
+# This is the rollback parachute — Ansible's commit alone has no auto-rollback.
+ssh chris@192.168.0.1
+configure
+commit-confirm 10  # changes auto-rollback in 10 minutes if not confirmed
+exit
+exit
+
+# In a separate terminal, run the playbook:
+cd router/ansible
+ansible-playbook site.yml [--tags <relevant>]
+
+# Verify reachability + functionality (depends on what changed)
+ssh chris@192.168.0.1 '/opt/vyatta/bin/vyatta-op-cmd-wrapper show interfaces'
+ssh chris@192.168.0.1 '/opt/vyatta/bin/vyatta-op-cmd-wrapper show firewall'
+ssh chris@192.168.0.1 '/opt/vyatta/bin/vyatta-op-cmd-wrapper show nat destination'
+# Test connectivity from a third location if possible (curl from outside, ping from a client device)
+
+# If everything works, confirm before the 10-minute timer expires:
+ssh chris@192.168.0.1
+configure
+confirm
+exit
+exit
+```
+
+If the timer elapses without `confirm`, VyOS rolls back automatically — including any Ansible-applied changes from that session, since they're all part of the same uncommitted set.
+
+## Apply without commit-confirm (low-risk changes only)
+
+For purely additive, non-network-path changes — DNS forwarder rules, NTP, container config tweaks, hostname:
+
+```bash
+cd router/ansible
+ansible-playbook site.yml --tags <relevant>
+# Verify
+ssh chris@192.168.0.1 '/opt/vyatta/bin/vyatta-op-cmd-wrapper show <whatever>'
+```
+
+When in doubt, treat it as high-risk.
+
+## Verify the backup landed
+
+```bash
+ls -ltr router/ansible/backups/ | tail -3
+```
+
+If no new file appeared after a run, the playbook didn't run its backup task → STOP, investigate.
+
+## Tags reference
+
+From `router/ansible/site.yml`:
+- `system` — hostname, NTP, DNS, console
+- `network` — interface config (HIGH RISK)
+- `firewall` — firewall groups + rules (HIGH RISK)
+- `nat` — port forwards + masquerade (HIGH RISK)
+- `services` — DHCP, syslog, prometheus exporter (MEDIUM RISK)
+- `monitoring` — prometheus + syslog only
+
+`network`, `firewall`, `nat` always need commit-confirm.
+
+## When to abort and surface
+
+- Reach test before deploy fails
+- `--check --diff` shows changes you didn't expect (drift from outside source)
+- Backup file isn't created during the run
+- Verification step fails after the deploy
+- Router becomes unreachable during the deploy
+
+If the router is unreachable: **wait for the commit-confirm timer to elapse** (10 min). Don't drive across town to the console unless you're sure you're outside the auto-rollback window.
+
+## What this skill does NOT do
+
+- Edit `router/ansible/group_vars/vyos_routers.yml` or playbooks for the user — that's a separate authoring task.
+- Manually mutate live router config (`set service dhcp-server …` outside the playbook). All changes flow through Ansible.
+- Decide whether a config change is correct. The user owns the *what*; this skill owns the *how to deploy safely*.
+- Bypass commit-confirm because "this change is small". The cost of being wrong is too high.


### PR DESCRIPTION
## Summary
Per the strategy decisions on #2506:

- **`safe-rollout`** — drives Deployment/StatefulSet/DaemonSet rollouts and Argo syncs to a definitive outcome via `Monitor`. Hard rules: no busy-loop polling, no `--force --grace-period=0`, no declaring success without verifying replica + event state. Codifies CLAUDE.md S3 patience rules.
- **`vyos-deploy`** — wraps router config changes in `commit-confirm 10` + Ansible `--check --diff` preview + post-deploy verification. Hard rule: SSH lock-out risk drives the requirement. Codifies CLAUDE.md S8.
- **`talos-upgrade`** — bumped etcd snapshot path from `/tmp/` to `~/etcd-snapshots/galaxy-<timestamp>.db` per dedicated-path preference. Snapshots accumulate; manually trim past 10.

After this lands, project skills cover: cluster-snapshot, ceph-doctor, talos-upgrade, safe-rollout, vyos-deploy. The remaining items in #2510 are the MCP server wiring and the `fewer-permission-prompts` allowlist run.

## Test plan
- [ ] Skills load: in a fresh Claude session both new skills appear in available-skills
- [ ] Triggering by description works
- [ ] Read-only / safety rules respected: ask the skill to do something destructive — should refuse

Refs #2506 #2510