### PR TITLE
kube-prometheus-stack 65.1.x -> 66.7.x (step 1 of stepwise upgrade)

### DIFF
--- a/cluster/applications/prometheus-stack.yaml
+++ b/cluster/applications/prometheus-stack.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 65.1.x
+    targetRevision: 66.7.x
     chart: kube-prometheus-stack
     helm:
       releaseName: prometheus
@@ -86,13 +86,12 @@ spec:
                 kubernetes_sd_configs:
                   - role: pod
                 relabel_configs:
-                  - source_labels:
-                      [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
                     action: keep
                     regex: true
               - job_name: vyos-snmp
                 static_configs:
-                  - targets: ["192.168.0.1:161"]
+                  - targets: [192.168.0.1:161]
                 metrics_path: /snmp
                 params:
                   module: [vyos]
@@ -113,7 +112,7 @@ spec:
                       storage: 200Gi
         grafana:
           admin:
-            existingSecret: "grafana-admin-secret"
+            existingSecret: grafana-admin-secret
             userKey: admin-user
             passwordKey: admin-password
           envFromSecret: azure-monitor-credentials


### PR DESCRIPTION
## Summary
First step of the stepwise upgrade plan in #2515. Bumps to chart **66.7.x** (latest 66.x patch).

| | Before | After |
|---|---|---|
| Chart | 65.1.x | 66.7.x |
| Prometheus | 2.x | 2.x (unchanged in 66.x) |
| Prometheus Operator | 0.77.x | 0.78.1 |
| Grafana | 11.x | 11.x (unchanged) |

Per the upstream UPGRADE.md, **65→66 has no value renames or field removals** — drop-in replacement.

The Prom v3 + Operator 0.79.0 transition (which DOES require `kubectl apply --server-side` of the CRDs) lands in chart 67.x and will be a separate PR.

## Test plan
- [ ] Merge → Argo applies the new chart values via the `kube-prometheus-stack` Application
- [ ] `kubectl -n prometheus rollout status deploy/prometheus-prometheus-operator` clean
- [ ] `kubectl -n prometheus get prometheus,alertmanager,servicemonitor -o yaml | grep -i kind` — CRD-backed resources still readable
- [ ] Grafana at https://dashboard.chrismiller.xyz still loads
- [ ] Prometheus targets still scraping (no 401/connection failures in `targets` page)
- [ ] Alertmanager pod still Running with the existing config

## Soak before next step
24h+ before opening the 66 → 67 PR. The 67 step is the bigger one (Prom v3 + CRD migration); we want a stable 66.x base.

Refs #2515