### PR TITLE
fluent-bit: mount emptyDir at /var/fluent-bit/state for tail/systemd DBs

### DIFF
--- a/cluster/applications/fluent-bit.yaml
+++ b/cluster/applications/fluent-bit.yaml
@@ -17,7 +17,7 @@ spec:
         replicaCount: 1
         image:
           repository: fluent/fluent-bit
-          tag: "2.2.2"
+          tag: 2.2.2
         serviceAccount:
           create: true
         rbac:
@@ -37,6 +37,12 @@ spec:
           - key: node-role.kubernetes.io/control-plane
             operator: Exists
             effect: NoSchedule
+        extraVolumes:
+          - name: state
+            emptyDir: {}
+        extraVolumeMounts:
+          - name: state
+            mountPath: /var/fluent-bit/state
         env:
           - name: AZURE_WORKSPACE_ID
             valueFrom:


### PR DESCRIPTION
## Summary
- All 3 `fluent-bit` DaemonSet pods have been CrashLoopBackOff for **275 days** (~77k restarts each).
- Root cause from container logs: tail/systemd inputs are configured with `DB /var/fluent-bit/state/*.db`, but no volume is mounted at that path. fluent-bit fails to open/create the sqlite cursor file and the engine exits at init.
- Fix: add a `state` emptyDir + mount so the input plugins can persist offsets across in-pod container restarts.

## Why emptyDir
Log tailing only needs the cursor to outlive a fluent-bit *container* restart inside the same pod, not the pod itself. emptyDir is the right scope — on pod reschedule, fluent-bit will re-tail from the start of whatever's currently in `/var/log/containers/*.log`, which is fine for a Talos node that rotates aggressively.

## Test plan
- [ ] Merge → Argo `fluent-bit` Application reconciles
- [ ] DaemonSet rolls — expect 3/3 pods Ready, 0 restarts after rollout
- [ ] Pod logs show the `[input:tail:tail.0]` and `[input:systemd:systemd.1]` lines without the `cannot open database` error
- [ ] Confirm logs reach Azure Log Analytics (the second OUTPUT) — visible in the workspace dashboard within ~5 min