### PR TITLE
rook: ServerSideApply=true to fix CSI CRD annotation overflow

### DIFF
--- a/cluster/applications/rook.yaml
+++ b/cluster/applications/rook.yaml
@@ -32,3 +32,4 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary
- Argo CD v3.4.1 (chart 9.x, landed in #2494) flipped the `rook` Application to **Degraded** because client-side apply fails on two large CSI CRDs:
  - `CustomResourceDefinition.apiextensions.k8s.io "drivers.csi.ceph.io"`
  - `CustomResourceDefinition.apiextensions.k8s.io "operatorconfigs.csi.ceph.io"`
- Both error with `metadata.annotations: Too long: must have at most 262144 bytes` — the `last-applied-configuration` annotation kubectl client-side apply writes is bigger than the 262 KB K8s annotation cap on these two CRDs.
- Argo's error message itself recommends server-side apply.

## Fix
Add `ServerSideApply=true` to the rook Application's `syncOptions`. Server-side apply manages field ownership directly and does not write the giant `last-applied-configuration` annotation.

## Scope
- Sync-mechanism only; **no Ceph runtime change**.
- Ceph remains `HEALTH_WARN` (spurious read errors on osd.4 / osd.6 — known noise) with all 81 PGs `active+clean`.
- Storage I/O continues to flow throughout the operation.

## Test plan
- [ ] Merge → rook Application reconciles via SSA
- [ ] `kubectl -n argo-cd get application rook` returns to `Synced/Healthy`
- [ ] The two CSI CRDs are present in cluster with up-to-date `metadata.managedFields` (proves SSA took ownership)
- [ ] Ceph still `HEALTH_WARN` only (spurious read errors); no PG state change

Refs #2494