### PR TITLE
cert-manager: ServerSideApply=true for big CRDs

### DIFF
--- a/cluster/applications/cert-manager.yaml
+++ b/cluster/applications/cert-manager.yaml
@@ -32,6 +32,7 @@ spec:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
+      - ServerSideApply=true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
## Summary
Same root cause as #2520 (rook): cert-manager ships 4 CRDs with large OpenAPI schemas (\`Certificate\`, \`CertificateRequest\`, \`Challenge\`, \`Order\`). Argo CD 3.4.1's default client-side apply produces patches that exceed the 262 KB \`metadata.annotations\` cap on these CRDs, so they are chronically reported as **OutOfSync** without ever being able to reconcile.

## Live state diagnosis
\`\`\`
$ kubectl -n argo-cd get application cert-manager -o json | jq '.status.resources[] | select(.status != "Synced")'
CustomResourceDefinition/certificaterequests.cert-manager.io: OutOfSync
CustomResourceDefinition/certificates.cert-manager.io: OutOfSync
CustomResourceDefinition/challenges.acme.cert-manager.io: OutOfSync
CustomResourceDefinition/orders.acme.cert-manager.io: OutOfSync
\`\`\`

## Fix
Add \`ServerSideApply=true\` to the \`cert-manager\` Application's \`syncOptions\`. Server-side apply manages field ownership via the K8s SSA endpoint and does not write the giant \`last-applied-configuration\` annotation.

## Scope
- Sync-mechanism only; no cert-manager runtime change.
- All \`Certificate\` / \`Issuer\` / \`ClusterIssuer\` resources remain untouched.
- The cert-manager controller, webhook, and cainjector continue running.

## Test plan
- [ ] Merge → cert-manager Application reconciles via SSA
- [ ] All 4 CRDs return to \`Synced/Healthy\`
- [ ] \`kubectl get cert-manager Application -o jsonpath='{.status.sync.status}'\` returns \`Synced\` (not \`OutOfSync\`)
- [ ] No regression in \`kubectl get certificates -A\` — all current certs still valid