### PR TITLE
postgres-operator: ServerSideDiff=true to stop mutating-webhook drift

### DIFF
--- a/cluster/applications/postgres-operator.yaml
+++ b/cluster/applications/postgres-operator.yaml
@@ -36,3 +36,4 @@ spec:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
+      - ServerSideDiff=true


### PR DESCRIPTION
## Summary
The Zalando postgres-operator ships a **mutating admission webhook** that injects defaults into \`OperatorConfiguration\` CRs (pod placement, repair_period, max_instances, etc.). With Argo CD's default client-side diff:

1. Argo compares the chart-rendered \`OperatorConfiguration\` (no defaults) against...
2. ...the live state, which has webhook-injected defaults.
3. The injected fields show as drift → Application is chronically \`OutOfSync/Healthy\`.

This Application has been **OutOfSync for 575+ days** for exactly this reason. The runtime is fine — it's purely a comparison-mechanism issue.

## Fix
\`ServerSideDiff=true\` (stable since Argo CD v3.1.0) computes the diff by asking the K8s API to do a server-side Apply dry-run.

Per the [Argo CD docs](https://argo-cd.readthedocs.io/en/latest/user-guide/diff-strategies/):
> "Server-Side Diff does not include changes made by mutation webhooks by default."

So fields added by the webhook are excluded from the diff calc — only fields Argo actually manages count toward sync status.

## Scope
- **Sync-mechanism only.** No postgres-operator runtime change.
- The OperatorConfiguration CR's actual content stays whatever the webhook makes it.
- All postgres clusters (\`acid-fit\` etc.) continue running.

## Test plan
- [ ] Merge → postgres-operator Application reconciles
- [ ] \`kubectl -n argo-cd get application postgres-operator -o jsonpath='{.status.sync.status}'\` returns \`Synced\` (not \`OutOfSync\`)
- [ ] No regression on running postgres clusters

## If it doesn't fully clear OutOfSync
The annotation \`argocd.argoproj.io/compare-options: IncludeMutationWebhook=true\` is the *inverse* — it would *include* webhook changes. We're explicitly NOT setting that, so the default exclusion applies.