### PR TITLE
postgres-operator: IncludeMutationWebhook=true (follow-up to #2523)

### DIFF
--- a/cluster/applications/postgres-operator.yaml
+++ b/cluster/applications/postgres-operator.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: postgres-operator
   namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
   project: default
   source:


### PR DESCRIPTION
## Summary
Follow-up to #2523. \`ServerSideDiff=true\` as a syncOption was the right *first step*, but the postgres-operator's webhook does more than inject defaults — it **restructures** incoming fields:

| Chart-rendered (desired) | Webhook-mutated (live) |
|---|---|
| \`configuration.debug_logging: true\` | \`configuration.debug.debug_logging: true\` |
| \`configuration.enable_database_access: true\` | \`configuration.debug.enable_database_access: true\` |

ServerSideDiff alone *excludes* webhook changes by default, so Argo's predicted state still has the top-level keys, while the live state has them nested. → still OutOfSync.

## Fix
The official Argo CD docs spell this out for exactly the "webhook mutates fields" scenario. The Application-level annotation opts *into* including webhook mutations in the diff:

\`\`\`yaml
metadata:
  annotations:
    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
\`\`\`

With \`IncludeMutationWebhook=true\`, Argo's dry-run SSA runs *with* the mutating webhook. The predicted post-webhook state then matches the live (post-webhook) state → converges to Synced.

## Test plan
- [ ] Merge → Argo picks up the annotation on next reconcile (\`Application\` itself is in argo-cd ns; \`applications\` app-of-apps will sync it)
- [ ] Trigger a sync of \`postgres-operator\` Application
- [ ] \`Synced/Healthy\` instead of \`OutOfSync/Healthy\`

## Note
The \`ServerSideDiff=true\` from the syncOption block stays — it's the underlying mechanism. The annotation just opts into the webhook inclusion on top of that.