### PR TITLE
postgres-operator: fix values path (configGeneral → configDebug) — real root cause of OutOfSync

### DIFF
--- a/cluster/applications/postgres-operator.yaml
+++ b/cluster/applications/postgres-operator.yaml
@@ -4,8 +4,6 @@ kind: Application
 metadata:
   name: postgres-operator
   namespace: argo-cd
-  annotations:
-    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
   project: default
   source:
@@ -23,7 +21,7 @@ spec:
           enable_persistent_volume_claim_deletion: false
           enable_sidecars: true
           share_pgsocket_with_sidecars: false
-        configGeneral:
+        configDebug:
           enable_database_access: true
           debug_logging: true
   destination:
@@ -38,4 +36,3 @@ spec:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
-      - ServerSideDiff=true


### PR DESCRIPTION
## Summary
The chronic 575+ day OutOfSync wasn't a mutating-webhook curiosity — it was a **values path bug in our Application**. We put two fields under \`configGeneral:\`, but the chart's \`values.yaml\` defines them under \`configDebug:\`.

\`\`\`yaml
# WRONG — what we had (chart silently rendered to top of configuration:)
configGeneral:
  enable_database_access: true
  debug_logging: true

# RIGHT — what the chart actually expects
configDebug:
  enable_database_access: true
  debug_logging: true
\`\`\`

## What the wrong path produced
- Chart rendered: \`configuration.debug_logging\` (top-level)
- CRD schema: this field does NOT exist
- Mutating webhook: rescues it by moving to \`configuration.debug.debug_logging\`
- Argo's diff: sees structural drift between rendered (top-level) and live (nested under debug) → OutOfSync forever

## What this PR does
1. **Renames \`configGeneral:\` → \`configDebug:\`** for those two fields — the only correctness change.
2. **Reverts PR #2523's \`ServerSideDiff=true\` syncOption** — was attempting to mask the underlying drift; not needed once drift is gone.
3. **Reverts PR #2524's \`compare-options\` annotation** — was attempting to opt into webhook-mutation diffing; instead it triggered ServerSideDiff which then failed schema validation (\`.configuration.enable_database_access: field not declared in schema\`) and flipped the Application to \`Unknown\` sync state.

## Test plan
- [ ] Merge → Argo re-renders the Application with the corrected path
- [ ] Trigger sync → chart now produces \`configuration.debug.{debug_logging,enable_database_access}\` matching both the CRD schema and the live state
- [ ] \`kubectl -n argo-cd get application postgres-operator -o jsonpath='{.status.sync.status}/{.status.health.status}'\` should return \`Synced/Healthy\`
- [ ] Postgres clusters (\`acid-fit\`, etc.) keep running

## Lessons
- ServerSideDiff is a great tool, but it can't fix a manifest that violates the target CRD's schema — the schema check fires before the webhook gets a chance to rewrite the field.
- When Argo says "chronic OutOfSync from a mutating webhook," check whether our manifest is *actually correct first.* The webhook may be working around our bug, not the other way around.

Refs PRs #2523 and #2524 (both effectively superseded).