### PR TITLE
attic: fix TOML parse — omit env-overridden fields

### DIFF
--- a/cluster/attic/server-config.yaml
+++ b/cluster/attic/server-config.yaml
@@ -17,7 +17,10 @@ data:
     require-proof-of-possession = true
 
     [database]
-      url = "%database_url%"
+      # url is set via ATTIC_SERVER_DATABASE_URL env from attic-db secret.
+      # Omitted from TOML because the template's literal "%database_url%"
+      # placeholder fails TOML parse — atticd evaluates env overrides AFTER
+      # parsing the file.
       heartbeat = false
 
     [storage]
@@ -37,6 +40,6 @@ data:
       interval = "12 hours"
 
     [jwt]
-
-    [jwt.signing]
-      token-rs256-secret-base64 = "%token_rs256_secret_base64%"
+    # Signing key is set via ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64 env
+    # from attic-server secret (RSA-4096 PEM PKCS1, base64-encoded).
+    # See note above re: omitting placeholder from TOML.


### PR DESCRIPTION
## Summary
Hot-fix: atticd crashlooped on startup with \`TOML parse error ... Invalid symbol 37, offset 0\` (37 = ASCII '%'). The template's \`%database_url%\` / \`%token_rs256_secret_base64%\` placeholders aren't interpolated by atticd — they're illustrative in the docs. atticd's TOML must parse first; env overrides apply *after*. So a literal '%' in those positions fails base64 decode at parse time.

Remove the placeholder lines entirely. \`ATTIC_SERVER_DATABASE_URL\` and \`ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64\` env vars (from the existing sealed secrets) supply the real values at runtime.

## Test plan
- [ ] Argo syncs, attic-0 progresses past TOML parse
- [ ] Pod will still CrashLoopBackoff on DB connect (placeholder password) — that's the documented bootstrap step from #2530, separate concern