### PR TITLE
satellites: trust self-hosted attic as substituter

### DIFF
--- a/satellites/modules/base.nix
+++ b/satellites/modules/base.nix
@@ -20,11 +20,16 @@ in
       "https://cache.nixos.org/"
       "https://nixos-raspberrypi.cachix.org"
       "https://christopherjmiller.cachix.org"
+      # Self-hosted attic (cluster-internal -> LAN-fast for satellites).
+      # nix fails-soft on unreachable substituters, so a cluster outage
+      # falls through to the cachix mirrors above without breaking deploys.
+      "https://attic.chrismiller.xyz/satellites"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
       "christopherjmiller.cachix.org-1:SpwpBjcK+4KV9+rd6V5+01ivGMu4KPBytdgbst3GNnE="
+      "satellites:sp9Ozvdr2daxB2tbfW3AeGFFuYpyf5tSKNqbGzEOjHA="
     ];
   };
   nix.gc.automatic = false;


### PR DESCRIPTION
## Summary
Phase 3 (final) of the cachix-self-hosted plan. Adds \`https://attic.chrismiller.xyz/satellites\` to the substituters and trusts its public key on every satellite.

### Key facts
- **Cache name:** \`satellites\` (public-read)
- **Public key:** \`satellites:sp9Ozvdr2daxB2tbfW3AeGFFuYpyf5tSKNqbGzEOjHA=\`
- **Endpoint:** \`https://attic.chrismiller.xyz/satellites\`

nix tries substituters in order and **falls through on miss/error**, so:
- If attic is unreachable → falls through to cachix → still works
- If a NAR signature fails verification → falls through → still works  
- LAN-fast in the common case (Pi and attic both on \`192.168.0.0/24\`)

### Side effect for the satellite Pis
This is a base.nix change which means **every satellite will need to evaluate the new flake** when comin polls — the now-familiar 16-min eval. Subsequent deploys benefit from attic in the substituter list and never have to build unit files locally.

### What still needs your action OUTSIDE this PR
To activate the CI push side (Phase 2 already merged but inert), set in repo settings:
\`\`\`
Variables:
  ATTIC_PUSH_ENABLED = true
  ATTIC_ENDPOINT     = https://attic.chrismiller.xyz/
  ATTIC_CACHE        = satellites

Secrets:
  ATTIC_TOKEN        = (push-only token I generated; will share via secure channel — DO NOT paste in chat)
\`\`\`

I can set the var values via \`gh\` for you on request; the secret you'd want to paste yourself from the secure channel.

## Test plan
- [ ] Merge -> comin polls -> evals (~16 min) -> activates -> \`nix.conf\` on the Pi shows the new substituter + key
- [ ] Once Phase 2 is activated (vars + secret), next workflow run pushes the toplevel to attic too
- [ ] Subsequent comin deploys on the Pi pull from attic instead of building locally — check \`journalctl -u comin\` for \`copying path ... from 'https://attic.chrismiller.xyz/satellites'\`