### PR TITLE
authentik: run acid-auth postgres with 2 instances

### DIFF
--- a/cluster/authentik/psql.yaml
+++ b/cluster/authentik/psql.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   databases:
     postgres: postgres
-  numberOfInstances: 1
+  numberOfInstances: 2
   spiloRunAsUser: 101
   spiloRunAsGroup: 103
   spiloFSGroup: 103


### PR DESCRIPTION
## Why

During the 2026-07-14 outage, the single `acid-auth-0` replica shut down cleanly after a kubelet/API blip on `bottom` (Patroni lost its leader lease, `failsafe_mode: false`) and then could not restart: the kubelet fsGroup recursive chmod had left the data dir at `2770`, which postgres refuses. Every service behind authentik forward-auth (radarr/sonarr/sabnzbd/auth) 503'd for ~34h.

## What

`numberOfInstances: 1 -> 2` for `acid-auth`, matching what `acid-media` already runs. Patroni streaming replication + automatic failover means a single wedged pod or node no longer takes down auth.

## Notes

- The operator will add `acid-auth-1` on a different node (pod anti-affinity via the operator's default spread).
- Recovery of the current outage was done live by deleting the wedged spilo pods (spilo re-applies `chmod 700` on PGDATA at container start); this PR is the recurrence guard.
- Follow-up worth considering separately: the same SPOF exists for `acid-chrismillerxyz`, `acid-fit`, `acid-ha`, `acid-royaltracker`.