### PR TITLE
postgres: synchronous_commit=off + patroni failsafe_mode on all acid clusters

### DIFF
--- a/cluster/attic/psql.yaml
+++ b/cluster/attic/psql.yaml
@@ -18,6 +18,10 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
+  patroni:
+    failsafe_mode: true
   teamId: acid
   users:
     attic:

--- a/cluster/authentik/psql.yaml
+++ b/cluster/authentik/psql.yaml
@@ -15,6 +15,10 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
+  patroni:
+    failsafe_mode: true
   teamId: acid
   users:
     postgres: []

--- a/cluster/chrismillerxyz/psql.yaml
+++ b/cluster/chrismillerxyz/psql.yaml
@@ -15,6 +15,8 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
   teamId: acid
   resources:
     requests:
@@ -28,6 +30,7 @@ spec:
   volume:
     size: 3Gi
   patroni:
+    failsafe_mode: true
     pg_hba:
       - local     all  all  trust
       - host      all  all  all  trust

--- a/cluster/fit/psql.yaml
+++ b/cluster/fit/psql.yaml
@@ -15,6 +15,10 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
+  patroni:
+    failsafe_mode: true
   teamId: acid
   users:
     postgres: []

--- a/cluster/home-assistant/psql.yaml
+++ b/cluster/home-assistant/psql.yaml
@@ -15,6 +15,10 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
+  patroni:
+    failsafe_mode: true
   teamId: acid
   users:
     postgres: []

--- a/cluster/media/psql.yaml
+++ b/cluster/media/psql.yaml
@@ -15,6 +15,10 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
+  patroni:
+    failsafe_mode: true
   teamId: acid
   users:
     postgres: []

--- a/cluster/royaltracker/psql.yaml
+++ b/cluster/royaltracker/psql.yaml
@@ -15,6 +15,10 @@ spec:
   spiloFSGroup: 103
   postgresql:
     version: '16'
+    parameters:
+      synchronous_commit: "off"
+  patroni:
+    failsafe_mode: true
   teamId: acid
   users:
     royaltracker:


### PR DESCRIPTION
## Why

The cluster's OSDs are all HDD-only BlueStore (data+DB+WAL on the spinners, no flash in the write path), so every postgres commit fsync pays 3×-replicated spinning-disk latency — the source of the long-standing `BLUESTORE_SLOW_OP` noise and sluggish DB-backed apps.

## What

For all 7 `acid-*` clusters:

- **`synchronous_commit: "off"`** — postgres acks commits from memory and batches WAL fsyncs in the background (`wal_writer_delay` cadence). Worst case on a crash: the last <1s of committed transactions are lost. WAL ordering is preserved, so **corruption is not possible** — unlike a filesystem/block-layer writeback cache. Right trade for homelab auth/media/tracker workloads on HDD Ceph.
- **`patroni.failsafe_mode: true`** — keeps the Patroni leader running through transient Kubernetes API unavailability instead of demoting + shutting postgres down. In the 2026-07-14 incident, an API blip on `bottom` triggered exactly that clean shutdown; postgres then couldn't restart (fsGroup-chmod'd data dir) and auth + several sites were down ~34h.

## Rollout

The operator applies parameter changes via Patroni without pod recreation (`synchronous_commit` is reloadable; no restart needed). No data migration, trivially revertible.

## Notes

- Hardware follow-up discussed separately: per-node SSD for BlueStore `metadataDevice` or an ssd-class pool for DB PVCs (current NVMe is the Talos system disk, fully consumed by EPHEMERAL, and hosts etcd — not usable for this).
- Complements #2586 (acid-auth → 2 instances).