### PR TITLE
hygiene: disable trivy node-collector, bound notion-sync retries

### DIFF
--- a/cluster/applications/trivy-operator.yaml
+++ b/cluster/applications/trivy-operator.yaml
@@ -14,6 +14,10 @@ spec:
       releaseName: trivy-operator
       valuesObject:
         operator:
+          # node-collector can never run here: trivy-system enforces PodSecurity
+          # baseline (hostPID + hostPath denied) and Talos lacks the host paths
+          # it inspects anyway. Disable instead of spamming FailedCreate forever.
+          infraAssessmentScannerEnabled: false
           resources:
             requests:
               cpu: 100m

--- a/cluster/chrismillerxyz/sync.yaml
+++ b/cluster/chrismillerxyz/sync.yaml
@@ -5,8 +5,12 @@ metadata:
   name: notion-sync
 spec:
   schedule: 0 */6 * * *
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # DB-unreachable failures aren't fixed by immediate retries — cap them
+      # (2026-07-14 outage produced 7 error pods per scheduled run).
+      backoffLimit: 2
       template:
         spec:
           securityContext:


### PR DESCRIPTION
trivy-operator's infra assessment spawns node-collector jobs that are
permanently rejected by trivy-system's PodSecurity baseline enforcement
(hostPID, hostPath) — and Talos nodes don't have the kubeadm host paths
it inspects anyway. Every scan cycle just emits FailedCreate warnings.

notion-sync gets backoffLimit=2 and concurrencyPolicy=Forbid so a
down database produces 3 attempts, not 7 error pods per window.
