### PR TITLE
CLAUDE.md: refresh known-sharp-edges to 2026-07 state

### DIFF
--- a/.claude/skills/talos-upgrade/SKILL.md
+++ b/.claude/skills/talos-upgrade/SKILL.md
@@ -57,17 +57,22 @@ For each node in order (`top` → `middle` → `bottom`):
 
 ```bash
 NODE_IP=192.168.0.240   # top
-NEW_INSTALLER=ghcr.io/siderolabs/installer:v1.X.Y
 
-# Pre-pull the installer to fail fast on bad image references
+# ⚠ ALWAYS the Image Factory installer with our schematic — NEVER
+# ghcr.io/siderolabs/installer, which strips the amdgpu-firmware/amd-ucode
+# extensions and breaks middle's GPU (see nodes/controlplane.yaml comment).
+# The schematic ID is version-independent; only the tag changes per hop.
+NEW_INSTALLER=factory.talos.dev/installer/173d42f096f07f5cc709f795178189dc64aa76ccad1a2193e5b3473f73f02a3e:v1.X.Y
+
+# Reference check (fail fast on a bad tag; doesn't warm the system namespace cache)
 TALOSCONFIG=nodes/talosconfig talosctl -n "$NODE_IP" image pull "$NEW_INSTALLER"
 
-# Trigger the upgrade with --preserve (keep machineConfig) and --reboot (immediate)
+# Trigger the upgrade. Reboot is implicit (there is no --reboot flag);
+# machine config is preserved by default (--preserve is deprecated since 1.13).
 TALOSCONFIG=nodes/talosconfig talosctl upgrade \
   -n "$NODE_IP" \
-  --preserve \
-  --reboot \
-  --image "$NEW_INSTALLER"
+  --image "$NEW_INSTALLER" \
+  --wait
 ```
 
 Talos will auto-cordon, drain, install, reboot, rejoin, uncordon. Refuses if quorum would break.
@@ -78,11 +83,12 @@ Use `Monitor` (or background bash) — **don't** busy-loop:
 
 1. **Node Ready**: `kubectl wait --for=condition=Ready node/<name> --timeout=10m`
 2. **Talos version**: `talosctl -n $NODE_IP version` returns the new version
-3. **etcd member**: `talosctl -n $NODE_IP service etcd` is Running/Healthy
-4. **Pods back**: `kubectl get pods -A -o wide --field-selector spec.nodeName=<name>` — count matches pre-upgrade, none Pending
-5. **Ceph settles**: `ceph -s` returns to its prior baseline. For `middle` specifically, both osd.4 and osd.6 must be `up` and any PGs that were `degraded` during the reboot must be back to clean.
+3. **Extensions survived**: `talosctl -n $NODE_IP get extensions` still lists amdgpu/amd-ucode (critical on `middle`)
+4. **etcd member**: `talosctl -n $NODE_IP service etcd` is Running/Healthy
+5. **Pods back**: `kubectl get pods -A -o wide --field-selector spec.nodeName=<name>` — count matches pre-upgrade, none Pending
+6. **Ceph settles**: `ceph -s` returns to its prior baseline. For `middle` specifically, both osd.4 and osd.6 must be `up` and any PGs that were `degraded` during the reboot must be back to clean.
 
-Only after all 5 pass: proceed to the next node.
+Only after all 6 pass: proceed to the next node.
 
 If any of these fails for > 15 min, stop and surface.
 
@@ -107,6 +113,16 @@ This upgrades apiserver, controller-manager, scheduler, proxy, kubelet, coredns 
 3. All Argo apps Synced + Healthy: `kubectl -n argo-cd get applications.argoproj.io -o wide`
 4. Run a deprecated-API scan (next minor's removals). Tools: `kubent`, or k8s API server logs for `deprecated_apis` warnings
 5. Wait 24h before the next minor — soak time catches latent breakage
+
+## Hop-specific hazards (researched 2026-07, Talos 1.9→1.13)
+
+- **1.8→1.9**: amdgpu moved from base image to extension; factory auto-migrates our schematic, but verify `middle`'s GPU (`get extensions` + dmesg) after the hop.
+- **1.10→1.11**: **etcd 3.5→3.6 major bump** rides along. Mandatory fresh etcd snapshot before node 1; scrutinize etcd health between every node.
+- **1.11→1.12**: kernel 6.12→6.18 (watch amdgpu + SATA controllers on middle), `module.sig_enforce=1`, stricter KSPP sysctls. `.machine.registries` (our docker.io pull-through mirror) deprecated — still works, migrate to `RegistryMirrorConfig` doc later.
+- **1.13**: use the latest patch (≥1.13.3) — 1.13.2 had a k8s-1.36 scheduler-config rendering bug (siderolabs/talos#13350). Use a talosctl ≥1.13 client.
+- **k8s must reach 1.31 before Talos 1.13** (its minimum). Full sequence: Talos 1.9 → 1.10 → k8s 1.31 → 1.32 → 1.33 → Talos 1.11 → k8s 1.34 → Talos 1.12 → 1.13 → k8s 1.35 → 1.36.
+- **After every Talos hop**: bump the `install.image` tag in `nodes/controlplane.yaml` and `talosctl apply-config` (no reboot for that field) — `talosctl upgrade --image` alone does not persist.
+- `upgrade-k8s` rewrites component image tags in machineconfig itself — no manual tag edits needed.
 
 ## Repo-side updates after upgrade
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,15 +131,15 @@ ssh admin@192.168.0.243 nixos-rebuild list-generations
 
 ---
 
-## Known sharp edges (current state, 2026-05)
+## Known sharp edges (current state, 2026-07)
 
 These are real problems in the current cluster — flag, don't silently fix:
 
-1. **Ceph `BLUESTORE_SPURIOUS_READ_ERRORS`** (HEALTH_WARN): osd.4 + osd.6 each show 1 retry. Confirmed noise — kernel reports zero ATA/SCSI/I-O errors on the underlying drives. Will auto-clear over time. (Earlier HEALTH_ERR with 2 inconsistent PGs in `media/mm-media` resolved 2026-05-10 via `pg repair`.)
-2. **`ingress-nginx` v1.15.1**: ingress-nginx is in maintenance until **March 2026** and then EOL. **InGate (the planned successor) was also abandoned.** Migration target chosen: **Traefik on the Ingress API** (see #2507). Not a same-day move; sequenced after Talos/k8s upgrade.
-3. **Talos v1.7.6 / k8s v1.30.3**: 4–6 minor versions behind on each. Upgrade path requires staggered minor jumps (Talos 1.7→…→1.11 for Phase 1, →1.13 for Phase 2; k8s 1.30→…→1.34→1.36), one node at a time, with Ceph healthy between each. Do not skip versions. See #2506 for the runbook.
-4. **Argo CD chart 7.9.1** — needs bump to 9.x before Phase 1 k8s upgrade. Renovate PR #2494 only bumps the chart version; values.yaml needs ingress-block edits for 8.x (see review on #2494).
-5. **kube-prometheus-stack 65.x** — ~20 minor versions stale. Stepwise upgrade required (#2515) before Phase 1 k8s past 1.32.
+1. **Ceph on SMR HDDs**: OSDs are ST8000DM004 (SMR) with BlueStore data+DB+WAL all on the spinners — chronic `BLUESTORE_SLOW_OP_ALERT` HEALTH_WARN noise is expected and non-blocking unless it escalates to ERR or PGs leave active+clean. Postgres fsync pain mitigated in software 2026-07 (#2587: `synchronous_commit=off` + patroni `failsafe_mode`). Real fix needs added flash per node (the NVMe is the Talos system disk + etcd — not usable). Buy CMR drives for replacements.
+2. **`ingress-nginx` is past EOL** (maintenance ended March 2026). Migration target: **Traefik on the Ingress API** (#2507 — full design + 26-ingress inventory done 2026-07). Side-by-side prep on MetalLB `.7` can proceed; final WAN cutover via router NAT flip after early #2506 hops.
+3. **Talos v1.8.4 / k8s v1.30.3**: k8s is >1 year past EOL. Hop sequence (no skips, one node at a time, Ceph healthy between): Talos 1.9 → 1.10 → k8s 1.31 → 1.32 → 1.33 → Talos 1.11 (etcd 3.5→3.6!) → k8s 1.34 → Talos 1.12 → 1.13 → k8s 1.35 → 1.36. See #2506 + the talos-upgrade skill (corrected 2026-07: factory installer image, not ghcr).
+4. **authentik 2024.12.3, chart pinned `2024.x.x`** — Renovate never offers 2025.x+. Upgrade path is strictly sequential (8 hops to 2026.5); per-hop pg_dump is non-negotiable (Django migrations don't roll back). No automated backup of acid-auth exists (`enableLogicalBackup` unset).
+5. **kube-prometheus-stack 79.12.0** — one stepwise hop to ~84.x remains (#2515).
 
 ---
 


### PR DESCRIPTION
Two months stale: Argo chart (now 10.1.4) and kube-prometheus-stack
(79.x) upgrades already landed, Talos moved to 1.8.4, ingress-nginx
passed EOL, and the Ceph warn signature changed to slow-ops on the SMR
drives. Adds authentik 2024.12 staleness + missing DB backups as a
tracked edge, and the researched Talos/k8s hop sequence.
