### PR TITLE
postgres: 2 instances for the public-site acid clusters

### DIFF
--- a/cluster/chrismillerxyz/psql.yaml
+++ b/cluster/chrismillerxyz/psql.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   databases:
     postgres: postgres
-  numberOfInstances: 1
+  numberOfInstances: 2
   spiloRunAsUser: 101
   spiloRunAsGroup: 103
   spiloFSGroup: 103

--- a/cluster/royaltracker/psql.yaml
+++ b/cluster/royaltracker/psql.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   databases:
     royaltracker: royaltracker
-  numberOfInstances: 1
+  numberOfInstances: 2
   spiloRunAsUser: 101
   spiloRunAsGroup: 103
   spiloFSGroup: 103


### PR DESCRIPTION
chrismillerxyz (chrismiller.xyz) and royaltracker (rccl-tracker) both
serve public sites off single-replica postgres — same SPOF that took
auth down on 2026-07-14 (#2586 fixed acid-auth). fit/ha/attic stay at
1: internal-only, and failsafe_mode already removed the main wedge
vector; not worth the extra RBD volumes.
