### PR TITLE
chrismillerxyz: allow standby replication in custom pg_hba

### DIFF
--- a/cluster/chrismillerxyz/psql.yaml
+++ b/cluster/chrismillerxyz/psql.yaml
@@ -32,6 +32,9 @@ spec:
   patroni:
     failsafe_mode: true
     pg_hba:
+      # "all" as database does NOT match replication connections — the standby
+      # needs an explicit entry or pg_basebackup from the replica fails.
+      - host      replication  standby  all  md5
       - local     all  all  trust
       - host      all  all  all  trust
       - hostnossl all  all  all  trust


### PR DESCRIPTION
The custom pg_hba list overrides spilo's defaults, and pg_hba's 'all'
database keyword does not match replication connections — so
acid-chrismillerxyz-1 (added in #2592) looped on pg_basebackup with
'no pg_hba.conf entry for replication connection'.
