### PR TITLE
plex: temporarily drop amd.com/gpu request (GPU dead on Talos 1.9)

### DIFF
--- a/cluster/applications/mega-media-release.yaml
+++ b/cluster/applications/mega-media-release.yaml
@@ -75,7 +75,9 @@ spec:
               cpu: 2
             limits:
               memory: 4Gi
-              amd.com/gpu: 1
+              # amd.com/gpu: 1  # TEMP removed 2026-07-16: middle's GPU fails init
+              # on Talos 1.9 kernel 6.12 ("Unable to locate a BIOS ROM") — plex
+              # was hard-down with 0 schedulable pods. Restore once GPU works.
           config:
             storageClassName: rook-ceph-block
           transcode:


### PR DESCRIPTION
middle's Polaris GPU fails init on Talos 1.9.6 / kernel 6.12:
'ROM: can't assign; bogus alignment' -> 'Unable to locate a BIOS ROM'
-> device plugin exposes 0 GPUs -> plex unschedulable (and it pod-
stormed 1400+ UnexpectedAdmissionError pods during the node upgrade,
since cleaned). CPU transcode until the vBIOS issue is fixed; most
sessions direct-play anyway. Revert this when amd.com/gpu is back.
