### PR TITLE
traefik: deploy side-by-side on 192.168.0.7 (#2507 phases 0-1)

### DIFF
--- a/cluster/applications/home-assistant-mosquitto.yaml
+++ b/cluster/applications/home-assistant-mosquitto.yaml
@@ -15,6 +15,10 @@ spec:
       valuesObject:
         service:
           type: LoadBalancer
+          annotations:
+            # Pin the IP mosquitto already holds by allocation — without
+            # this a restart could grab .7, which Traefik needs (#2507).
+            metallb.universe.tf/loadBalancerIPs: 192.168.0.8
         persistence:
           storageClass: rook-ceph-block
           size: 5Gi

--- a/cluster/applications/kustomization.yaml
+++ b/cluster/applications/kustomization.yaml
@@ -43,5 +43,7 @@ resources:
   - prometheus-snmp-exporter.yaml
   - sealed-secrets.yaml
   - share.yaml
+  - traefik.yaml
+  - traefik-release.yaml
   - trivy-operator.yaml
   - word-arena.yaml

--- a/cluster/applications/traefik-release.yaml
+++ b/cluster/applications/traefik-release.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik-release
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://traefik.github.io/charts
+    targetRevision: 41.x.x
+    chart: traefik
+    helm:
+      releaseName: traefik
+      valuesObject:
+        deployment:
+          kind: Deployment
+          replicas: 2
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: traefik
+                  topologyKey: kubernetes.io/hostname
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 256Mi
+        ingressClass:
+          enabled: true
+          # nginx stays the default until the router cutover bakes (#2507
+          # phase 4); flip only after nginx is decommissioned.
+          isDefaultClass: false
+          name: traefik
+        providers:
+          kubernetesIngress:
+            enabled: true
+            publishedService:
+              enabled: true
+          kubernetesCRD:
+            enabled: true
+            # Ingresses in media/ops/share reference the shared ForwardAuth
+            # Middleware living in the authentik namespace.
+            allowCrossNamespace: true
+          kubernetesGateway:
+            enabled: false
+        service:
+          annotations:
+            metallb.universe.tf/address-pool: pool
+            metallb.universe.tf/loadBalancerIPs: 192.168.0.7
+        ports:
+          web:
+            redirections:
+              entryPoint:
+                to: websecure
+                scheme: https
+                permanent: true
+            transport:
+              respondingTimeouts:
+                # Traefik v3 defaults to 60s for the ENTIRE request incl.
+                # body — would break attic multi-GB pushes and webdav
+                # uploads. 0 restores nginx-era behavior; per-router
+                # timeouts don't exist (#2507 flagged trade-off).
+                readTimeout: 0
+          websecure:
+            transport:
+              respondingTimeouts:
+                readTimeout: 0
+        # argo-cd's backend is self-signed HTTPS; nginx never verified it
+        # either (backend-protocol: HTTPS with no CA config).
+        additionalArguments:
+          - --serversTransport.insecureSkipVerify=true
+        logs:
+          access:
+            enabled: true
+        metrics:
+          prometheus:
+            serviceMonitor:
+              enabled: true
+              additionalLabels:
+                release: prometheus
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: traefik
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/cluster/applications/traefik.yaml
+++ b/cluster/applications/traefik.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ChristopherJMiller/luma-homeops.git
+    path: cluster/traefik
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: traefik
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground

--- a/cluster/traefik/kustomization.yaml
+++ b/cluster/traefik/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - middlewares.yaml

--- a/cluster/traefik/middlewares.yaml
+++ b/cluster/traefik/middlewares.yaml
@@ -1,0 +1,41 @@
+---
+# Shared authentik forward-auth for Traefik-class ingresses. The existing
+# domain-level outpost serves /auth/traefik natively — no authentik-side
+# change needed vs the nginx auth_request wiring.
+# Attach with:
+#   traefik.ingress.kubernetes.io/router.middlewares: authentik-authentik-forward-auth@kubernetescrd
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: authentik-forward-auth
+  namespace: authentik
+spec:
+  forwardAuth:
+    address: http://ak-outpost-media-outpost.authentik.svc.cluster.local:9000/outpost.goauthentik.io/auth/traefik
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-authentik-username
+      - X-authentik-groups
+      - X-authentik-entitlements
+      - X-authentik-email
+      - X-authentik-name
+      - X-authentik-uid
+      - X-authentik-jwt
+      - X-authentik-meta-jwks
+      - X-authentik-meta-outpost
+      - X-authentik-meta-provider
+      - X-authentik-meta-app
+      - X-authentik-meta-version
+---
+# Equivalent of the nginx `more_clear_headers "Content-Security-Policy"`
+# snippet used by 13 ingresses (empty value deletes the header).
+# Attach with: traefik-strip-csp@kubernetescrd
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-csp
+  namespace: traefik
+spec:
+  headers:
+    customResponseHeaders:
+      Content-Security-Policy: ""


### PR DESCRIPTION
Phase 0: pin mosquitto to the .8 it holds by allocation, so a restart
can't steal .7.

Phase 1: Traefik chart 41.x (proxy v3.7) as a second ingress
controller — 2 replicas + PDB + anti-affinity, LB pinned to .7,
ingressClass 'traefik' (NOT default), Ingress API + CRD providers.
Entrypoint readTimeout=0 (v3's 60s whole-request default would break
attic/webdav uploads), global HTTP->HTTPS redirect, ServiceMonitor.
Pre-creates the shared authentik ForwardAuth middleware (outpost
serves /auth/traefik natively) and the CSP-strip middleware.

No traffic moves: WAN NAT still points at nginx on .6. Next: duplicate
test ingresses starting with realmic, then the router cutover after
early #2506 hops (full design on #2507).
