### PR TITLE
traefik: fix chart-41 values schema; add first migration ingress (realmic)

### DIFF
--- a/cluster/applications/kustomization.yaml
+++ b/cluster/applications/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
   - sealed-secrets.yaml
   - share.yaml
   - traefik.yaml
+  - traefik-migration.yaml
   - traefik-release.yaml
   - trivy-operator.yaml
   - word-arena.yaml

--- a/cluster/applications/traefik-migration.yaml
+++ b/cluster/applications/traefik-migration.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik-migration
+  namespace: argo-cd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ChristopherJMiller/luma-homeops.git
+    path: cluster/traefik-migration
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - PrunePropagationPolicy=foreground

--- a/cluster/applications/traefik-release.yaml
+++ b/cluster/applications/traefik-release.yaml
@@ -58,11 +58,12 @@ spec:
             metallb.universe.tf/loadBalancerIPs: 192.168.0.7
         ports:
           web:
-            redirections:
-              entryPoint:
-                to: websecure
-                scheme: https
-                permanent: true
+            http:
+              redirections:
+                entryPoint:
+                  to: websecure
+                  scheme: https
+                  permanent: true
             transport:
               respondingTimeouts:
                 # Traefik v3 defaults to 60s for the ENTIRE request incl.
@@ -78,9 +79,8 @@ spec:
         # either (backend-protocol: HTTPS with no CA config).
         additionalArguments:
           - --serversTransport.insecureSkipVerify=true
-        logs:
-          access:
-            enabled: true
+        accessLog:
+          enabled: true
         metrics:
           prometheus:
             serviceMonitor:

--- a/cluster/traefik-migration/kustomization.yaml
+++ b/cluster/traefik-migration/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# TEMPORARY (#2507 phase 2): duplicate Ingresses on the traefik class for
+# validation via 192.168.0.7 while public traffic stays on nginx/.6.
+# Delete this whole app in phase 4 when the originals are rewritten.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - realmic.yaml

--- a/cluster/traefik-migration/realmic.yaml
+++ b/cluster/traefik-migration/realmic.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: realmic-traefik
+  namespace: realmic
+  labels:
+    service: web
+  annotations:
+    # Same CNAME target as the nginx original — external-dns dedupes.
+    external-dns.alpha.kubernetes.io/target: realliance.net
+    # Equivalent of the nginx more_clear_headers CSP snippet.
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-strip-csp@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - legacy.realliance.net
+      secretName: realmic-tls
+  rules:
+    - host: legacy.realliance.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: home
+                port:
+                  number: 80


### PR DESCRIPTION
The chart's values.schema.json rejected two keys from the initial
deploy: redirections moved under ports.web.http, and access logging is
top-level accessLog (not logs.access). Verified with helm template
against 41.0.2.

Also adds the temporary traefik-migration app with the first duplicate
Ingress: realmic-traefik (legacy.realliance.net, traefik class,
strip-csp middleware) — validated via curl --resolve against .7 before
anything else migrates.
