### PR TITLE
traefik-migration: batch 2 — 13 trivial/medium duplicate ingresses

### DIFF
--- a/cluster/traefik-migration/batch2.yaml
+++ b/cluster/traefik-migration/batch2.yaml
@@ -1,0 +1,322 @@
+---
+# Phase-2 batch: trivial/medium ingresses duplicated on the traefik class.
+# proxy-body-size / read/send-timeout annotations are intentionally dropped:
+# Traefik has no default body limit and the entrypoints run readTimeout=0.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: attic-traefik
+  namespace: attic
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [attic.chrismiller.xyz]
+      secretName: attic-tls
+  rules:
+    - host: attic.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: attic
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chrismillerxyz-traefik
+  namespace: chrismillerxyz
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: cloudflareddns
+    traefik.ingress.kubernetes.io/router.middlewares: chrismillerxyz-cors@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [chrismiller.xyz]
+      secretName: chrismillerxyz-tls
+  rules:
+    - host: chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mysite
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: www-chrismillerxyz-traefik
+  namespace: chrismillerxyz
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+    traefik.ingress.kubernetes.io/router.middlewares: chrismillerxyz-cors@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [www.chrismiller.xyz]
+      secretName: chrismillerxyz-tls
+  rules:
+    - host: www.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mysite
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fittrackee-traefik
+  namespace: fit
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-strip-csp@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [fit.chrismiller.xyz]
+      secretName: fit-tls
+  rules:
+    - host: fit.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fit-fittrackee
+                port:
+                  number: 5000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: home-assistant-traefik
+  namespace: home-assistant
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-strip-csp@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [home.chrismiller.xyz]
+      secretName: home-tls
+  rules:
+    - host: home.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ha-home-assistant
+                port:
+                  number: 8123
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: plex-traefik
+  namespace: media
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+    traefik.ingress.kubernetes.io/router.middlewares: traefik-strip-csp@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [plex.chrismiller.xyz]
+      secretName: plex-tls
+  rules:
+    - host: plex.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mm-plex
+                port:
+                  number: 32400
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mediadav-traefik
+  namespace: media
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [mediadav.chrismiller.xyz]
+      secretName: mediadav-tls
+  rules:
+    - host: mediadav.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: webdav
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gonic-traefik
+  namespace: music-streaming
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [music.chrismiller.xyz]
+      secretName: gonic-tls
+  rules:
+    - host: music.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gonic
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gonic-webdav-traefik
+  namespace: music-streaming
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [dav.music.chrismiller.xyz]
+      secretName: gonic-webdav-tls
+  rules:
+    - host: dav.music.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gonic
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-traefik
+  namespace: prometheus
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [dashboard.chrismiller.xyz]
+      secretName: dashboard-tls
+  rules:
+    - host: dashboard.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus-grafana
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: realliance-traefik
+  namespace: realliance-net
+  annotations:
+    external-dns.alpha.kubernetes.io/controller: cloudflareddns
+    traefik.ingress.kubernetes.io/router.middlewares: realliance-net-set-csp@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [realliance.net]
+      secretName: realliance-tls
+  rules:
+    - host: realliance.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: home
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: www-realliance-traefik
+  namespace: realliance-net
+  annotations:
+    external-dns.alpha.kubernetes.io/target: realliance.net
+    traefik.ingress.kubernetes.io/router.middlewares: realliance-net-set-csp@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [www.realliance.net]
+      secretName: chrismillerxyz-tls
+  rules:
+    - host: www.realliance.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: home
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: royaltracker-traefik
+  namespace: royaltracker
+  annotations:
+    external-dns.alpha.kubernetes.io/target: chrismiller.xyz
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts: [rccl-tracker.chrismiller.xyz]
+      secretName: royaltracker-tls
+  rules:
+    - host: rccl-tracker.chrismiller.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: royaltracker-bot
+                port:
+                  number: 80

--- a/cluster/traefik-migration/kustomization.yaml
+++ b/cluster/traefik-migration/kustomization.yaml
@@ -6,3 +6,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - realmic.yaml
+  - middlewares-extra.yaml
+  - batch2.yaml

--- a/cluster/traefik-migration/middlewares-extra.yaml
+++ b/cluster/traefik-migration/middlewares-extra.yaml
@@ -1,0 +1,34 @@
+---
+# nginx enable-cors:true equivalent for the chrismillerxyz site (mirrors
+# ingress-nginx CORS defaults).
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: cors
+  namespace: chrismillerxyz
+spec:
+  headers:
+    accessControlAllowOriginList:
+      - "*"
+    accessControlAllowCredentials: true
+    accessControlAllowMethods:
+      - GET
+      - PUT
+      - POST
+      - DELETE
+      - PATCH
+      - OPTIONS
+    accessControlAllowHeaders:
+      - "*"
+    accessControlMaxAge: 1728000
+---
+# realliance.net's more_set_headers CSP equivalent.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: set-csp
+  namespace: realliance-net
+spec:
+  headers:
+    customResponseHeaders:
+      Content-Security-Policy: "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; connect-src 'self'; font-src 'self' data:; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"


### PR DESCRIPTION
attic, chrismillerxyz+www (CORS middleware), fittrackee, home-assistant,
plex, mediadav, gonic x2, grafana, realliance+www (CSP-set middleware),
royaltracker — all on the traefik class against .7, translated per the
#2507 annotation mapping (body-size/timeout annotations dropped by
design: no default limit + entrypoint readTimeout=0). Public traffic
still on nginx/.6. Remaining for later batches: word-arena (sticky),
the 8 forward-auth ingresses, argo-cd (HTTPS backend), authentik.
