### PR TITLE
ipmi-exporter: writable HOME/tmp for freeipmi SDR cache

### DIFF
--- a/cluster/ipmi-exporter/deployment.yaml
+++ b/cluster/ipmi-exporter/deployment.yaml
@@ -31,6 +31,11 @@ spec:
           image: quay.io/prometheuscommunity/ipmi-exporter:v1.10.1
           args:
             - --config.file=/config/config.yml
+          env:
+            # freeipmi writes its SDR cache under $HOME/.freeipmi; without a
+            # writable HOME every collector fails with "read-only file system".
+            - name: HOME
+              value: /tmp
           ports:
             - name: http
               containerPort: 9290
@@ -44,6 +49,8 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 10m
@@ -54,3 +61,6 @@ spec:
         - name: config
           secret:
             secretName: ipmi-exporter-config
+        - name: tmp
+          emptyDir:
+            medium: Memory


### PR DESCRIPTION
All collectors failed with "read-only file system": freeipmi writes its
SDR cache under $HOME/.freeipmi. Keep readOnlyRootFilesystem, mount a
memory emptyDir at /tmp and set HOME=/tmp.

Claude-Session: https://claude.ai/code/session_01J6jjTh4jNuToFm8PCschw8
